### PR TITLE
Add user fields to User model

### DIFF
--- a/src/ZendeskApi.Contracts/Models/User.cs
+++ b/src/ZendeskApi.Contracts/Models/User.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Runtime.Serialization;
@@ -92,5 +92,8 @@ namespace ZendeskApi.Contracts.Models
 
         [DataMember(Name = "ticket_restriction", EmitDefaultValue = false)]
         public string TicketRestriction { get; set; }
+
+        [DataMember(Name = "user_fields", EmitDefaultValue = false)]
+        public Dictionary<string, object> UserFields { get; set; }
     }
 }


### PR DESCRIPTION
Add user fields to User model to support Zendesk custom fields. See `user_fields` under https://developer.zendesk.com/rest_api/docs/core/users.